### PR TITLE
hotfix/fix regex fail

### DIFF
--- a/src/constants/validationRules.json
+++ b/src/constants/validationRules.json
@@ -27,8 +27,8 @@
       "message": "Password must be at least 8 characters"
     },
     "pattern": {
-      "value": "^(?=.*[0-9])(?=.*[!@#$%^&*.])[a-zA-Z0-9!@#$%^&*.]{6,16}$",
-      "message": "Password must contain at least one uppercase letter, one lowercase letter, and one number"
+      "value": "^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,}$",
+      "message": "Password must contain at least one uppercase letter, one lowercase letter, one digit and one special character"
     }
   },
   "emailRule": {

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,6 +1,6 @@
 // utils
-import * as yup from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
 // styles
 
 // contexts
@@ -12,23 +12,23 @@ import useWindowSize from "@hooks/useWindowSize";
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 //components
-import { Button, Checkbox, Input } from "@nextui-org/react";
-import LogoNike from "../../public/assets/logo/logo_nike.svg";
-import { Controller, SubmitHandler, useForm } from "react-hook-form";
-import { useMutation } from "@tanstack/react-query";
-import { RegisterForm } from "@services/users.api";
-import { isAxiosError, isAxiosUnprocessableEntityError } from "@utils/utils";
-import { ResponseApi } from "@utils/utils.type";
-import useDocumentTitle from "@hooks/useDocumentTitle";
 import {
   EyeFilledIcon,
   EyeSlashFilledIcon,
   ThirdParyButton,
 } from "@components/index";
+import useDocumentTitle from "@hooks/useDocumentTitle";
+import { Button, Checkbox, Input } from "@nextui-org/react";
+import { RegisterForm } from "@services/users.api";
 import usersService from "@services/users.service";
-import { FcGoogle } from "react-icons/fc";
-import { FaFacebook } from "react-icons/fa";
+import { useMutation } from "@tanstack/react-query";
 import { isProduction } from "@utils/http";
+import { isAxiosError, isAxiosUnprocessableEntityError } from "@utils/utils";
+import { ResponseApi } from "@utils/utils.type";
+import { Controller, SubmitHandler, useForm } from "react-hook-form";
+import { FaFacebook } from "react-icons/fa";
+import { FcGoogle } from "react-icons/fc";
+import LogoNike from "../../public/assets/logo/logo_nike.svg";
 
 const schema: yup.ObjectSchema<Omit<RegisterForm, "email" | "phone_number">> =
   yup.object().shape({
@@ -330,13 +330,13 @@ const Register = () => {
                   <p
                     className={`mt-2 text-xs ${errors.password?.types?.min || errors.password?.types?.optionality ? "" : "text-black"}`}
                   >
-                    Minumum of 8 characters
+                    Minimum is 8 characters
                   </p>
                   <p
                     className={`mt-2 text-xs ${errors.password?.types?.matches || errors.password?.types?.optionality ? "" : "text-black"}`}
                   >
-                    Uppercase, lowercase letters, one number and special
-                    characters
+                    Password must contain at least one uppercase letter, one
+                    lowercase letter, one digit and one special character
                   </p>
                 </div>
                 <Controller


### PR DESCRIPTION
@quyn2904 

# Changed regex validate password field
- ref from: https://stackoverflow.com/questions/19605150/regex-for-password-must-contain-at-least-eight-characters-at-least-one-number-a

```txt
^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,}$
```
  - At least one upper case English letter, (?=.*?[A-Z])
  - At least one lower case English letter, (?=.*?[a-z])
  - At least one digit, (?=.*?[0-9])
  - At least one special character, (?=.*?[#?!@$%^&*-])
  - Minimum eight in length .{8,} (with the anchors) 

# Change the error message corresponding

- If passed, error message will turn to black else it still red

![image](https://github.com/PiedTeam/NikeCloneTraining-FE-Project/assets/136492579/917e392c-820a-4e9c-b188-331bea6cf603)
***
![image](https://github.com/PiedTeam/NikeCloneTraining-FE-Project/assets/136492579/58ac0f22-38ae-4ffb-b33d-3ec29b64845e)
***
![image](https://github.com/PiedTeam/NikeCloneTraining-FE-Project/assets/136492579/5475914e-0b79-4cbd-acaa-62e8fdc4ca22)
***
![image](https://github.com/PiedTeam/NikeCloneTraining-FE-Project/assets/136492579/2d2d858d-15e7-43d9-baf8-11dad271a4a3)
***
![image](https://github.com/PiedTeam/NikeCloneTraining-FE-Project/assets/136492579/d449a31c-7857-41ee-b322-ab78a6dcb00a)
***
